### PR TITLE
Adds check if this._pipeline is defined before calling functions on it

### DIFF
--- a/lib/websocket_extensions.js
+++ b/lib/websocket_extensions.js
@@ -130,11 +130,13 @@ var instance = {
   },
 
   processIncomingMessage: function(message, callback, context) {
-    this._pipeline.processIncomingMessage(message, callback, context);
+    if(this._pipeline) this._pipeline.processIncomingMessage(message, callback, context);
+    else callback(true);
   },
 
   processOutgoingMessage: function(message, callback, context) {
-    this._pipeline.processOutgoingMessage(message, callback, context);
+    if(this._pipeline) this._pipeline.processOutgoingMessage(message, callback, context);
+    else callback(true);
   },
 
   close: function(callback, context) {


### PR DESCRIPTION
The Firebase library (https://www.npmjs.com/package/firebase), which depends on faye-websocket which depends on websocket-driver which depends on websocket_extensions, sometimes
crashes due to the fact that this._pipeline is undefined when calling
processIncomingMessage(). This commit will at least prevent that, and callback
with an error.

See stacktrace below:

`TypeError: Cannot read property 'processIncomingMessage' of undefined
    at instance.processIncomingMessage (/node_modules/firebase/node_modules/faye-websocket/node_modules/websocket-driver/node_modules/websocket-extensions/lib/websocket_extensions.js:133:19)
    at instance._emitMessage (/node_modules/firebase/node_modules/faye-websocket/node_modules/websocket-driver/lib/websocket/driver/hybi.js:442:22)
    at instance._emitFrame (/node_modules/firebase/node_modules/faye-websocket/node_modules/websocket-driver/lib/websocket/driver/hybi.js:405:19)
    at instance.parse (/node_modules/firebase/node_modules/faye-websocket/node_modules/websocket-driver/lib/websocket/driver/hybi.js:144:18)
    at instance.parse (/node_modules/firebase/node_modules/faye-websocket/node_modules/websocket-driver/lib/websocket/driver/client.js:56:58)
    at IO.write (/node_modules/firebase/node_modules/faye-websocket/node_modules/websocket-driver/lib/websocket/streams.js:80:16)
    at TLSSocket.ondata (_stream_readable.js:536:20)
    at emitOne (events.js:77:13)
    at TLSSocket.emit (events.js:169:7)
    at readableAddChunk (_stream_readable.js:153:18)`